### PR TITLE
Added function "commit" that gets the short hash for the current commit

### DIFF
--- a/bin/commit
+++ b/bin/commit
@@ -1,0 +1,4 @@
+commit=`git rev-parse --short HEAD`
+echo $commit
+[ "$commit" != "" ] && exit 1
+exit 0

--- a/index.js
+++ b/index.js
@@ -85,3 +85,13 @@ var status = function (repo, cb) {
 var truthy = function (obj) {
   return !!obj
 }
+
+exports.commit = function (repo, cb) {
+  exec('git rev-parse --short HEAD', { cwd: repo }, function (err, stdout, stderr) {
+    if (err) return cb(err)
+
+    var commitHash = stdout.trim()
+
+    cb(null, commitHash)
+  })
+}

--- a/test.js
+++ b/test.js
@@ -67,3 +67,12 @@ test('#ahead()', function (t) {
     t.end()
   })
 })
+
+test('#commit()', function (t) {
+  var dir = process.cwd()
+  git.commit(dir, function (err, result) {
+    t.error(err)
+    t.equal(typeof result, 'string')
+    t.end()
+  })
+})


### PR DESCRIPTION
Added a function “commit” for getting the short-hash for the current commit in a repo. In practice it simply calls `git rev-parse --short HEAD`.

This is useful if you for instance want to create good log files in a build system.
