### PR TITLE
Don't use bashisms in child_process.exec

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,14 +56,14 @@ exports.dirty = function (repo, cb) {
 }
 
 exports.branch = function (repo, cb) {
-  exec('git show-ref &> /dev/null && git rev-parse --abbrev-ref HEAD', { cwd: repo }, function (err, stdout, stderr) {
+  exec('git show-ref >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD', { cwd: repo }, function (err, stdout, stderr) {
     if (err) return cb() // most likely the git repo doesn't have any commits yet
     cb(null, stdout.trim())
   })
 }
 
 exports.ahead = function (repo, cb) {
-  exec('git show-ref &> /dev/null && git rev-list HEAD --not --remotes', { cwd: repo }, function (err, stdout, stderr) {
+  exec('git show-ref >/dev/null 2>&1 && git rev-list HEAD --not --remotes', { cwd: repo }, function (err, stdout, stderr) {
     if (err) return cb(null, NaN) // depending on the state of the git repo, the command might return non-0 exit code
     stdout = stdout.trim()
     cb(null, !stdout ? 0 : parseInt(stdout.split(os.EOL).length, 10))


### PR DESCRIPTION
Hi!

When I am on the master branch of my local clone of this repo,

``` js
gitState.branch('.', (err, branch) => console.log(!err && branch))
```

gives me this:

```
master
1d0f2f65d93874ad57543d3bedb653355ada7f36 refs/heads/master
1d0f2f65d93874ad57543d3bedb653355ada7f36 refs/remotes/origin/HEAD
1d0f2f65d93874ad57543d3bedb653355ada7f36 refs/remotes/origin/master
0115c3a173559b1e6597e93bbb862aa3271faa53 refs/tags/v1.0.0
d744bede9a49a540b0093429ac47ca4f9531f4e7 refs/tags/v1.0.1
1898ac048bb9298b9d34bd3caf14764fb3c226e2 refs/tags/v2.0.0
9b80703fb08512ce91b75a63b31ceea4c1438d36 refs/tags/v2.1.0
bcd7d553fc61c9a3a2265cd79369237621e228be refs/tags/v2.2.0
459f60bda3cd9bd9062cf8159d56f9477f916257 refs/tags/v2.2.1
11aab123f88f9b7450f5e5c87a635a0e460b0890 refs/tags/v2.2.2
c859cbb4dc3b5fb95b9f038778b6235fad2faaf9 refs/tags/v2.2.3
60628d705c3aec68d7766cc5fef8112319d41abd refs/tags/v2.2.4
c6af6585193c20a9dc5e0761556e474754f33d1b refs/tags/v2.2.5
c8c22787a158e5447c8e612a21815cc3e65e3f77 refs/tags/v2.3.0
41bc067cdef55874ea4da13ef8ae39b33e054572 refs/tags/v2.4.0
abb2d8805099d67ed4015bff92524d835e9b1ae6 refs/tags/v2.5.0
```

This is because my `/bin/sh` points to `/bin/dash` which does not support the `&>` construct from Bash for redirecting both stdout and stderr.

This patch replaces the uses of this construct with a POSIX-compatible alternative, namely `>word 2>&1`.
