### PR TITLE
added windows compatibility for STDERR null paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,10 @@ var path = require('path')
 var exec = require('child_process').exec
 var afterAll = require('after-all-results')
 
-var VALID_BRANCHES = ['master', 'gh-pages']
+var VALID_BRANCHES = ['master', 'gh-pages'];
+
+//Prevent from failing on windows
+var nullPath = /^win/.test(process.platform) ? 'nul' : '/dev/null';
 
 exports.isGit = function (dir, cb) {
   fs.exists(path.join(dir, '.git'), cb)
@@ -56,14 +59,14 @@ exports.dirty = function (repo, cb) {
 }
 
 exports.branch = function (repo, cb) {
-  exec('git show-ref >/dev/null 2>&1 && git rev-parse --abbrev-ref HEAD', { cwd: repo }, function (err, stdout, stderr) {
+  exec('git show-ref >'+nullPath+' 2>&1 && git rev-parse --abbrev-ref HEAD', { cwd: repo }, function (err, stdout, stderr) {
     if (err) return cb() // most likely the git repo doesn't have any commits yet
     cb(null, stdout.trim())
   })
 }
 
 exports.ahead = function (repo, cb) {
-  exec('git show-ref >/dev/null 2>&1 && git rev-list HEAD --not --remotes', { cwd: repo }, function (err, stdout, stderr) {
+  exec('git show-ref >'+nullPath+' 2>&1 && git rev-list HEAD --not --remotes', { cwd: repo }, function (err, stdout, stderr) {
     if (err) return cb(null, NaN) // depending on the state of the git repo, the command might return non-0 exit code
     stdout = stdout.trim()
     cb(null, !stdout ? 0 : parseInt(stdout.split(os.EOL).length, 10))

--- a/index.js
+++ b/index.js
@@ -6,10 +6,10 @@ var path = require('path')
 var exec = require('child_process').exec
 var afterAll = require('after-all-results')
 
-var VALID_BRANCHES = ['master', 'gh-pages'];
+var VALID_BRANCHES = ['master', 'gh-pages']
 
-//Prevent from failing on windows
-var nullPath = /^win/.test(process.platform) ? 'nul' : '/dev/null';
+// Prevent from failing on windows
+var nullPath = /^win/.test(process.platform) ? 'nul' : '/dev/null'
 
 exports.isGit = function (dir, cb) {
   fs.exists(path.join(dir, '.git'), cb)
@@ -59,14 +59,14 @@ exports.dirty = function (repo, cb) {
 }
 
 exports.branch = function (repo, cb) {
-  exec('git show-ref >'+nullPath+' 2>&1 && git rev-parse --abbrev-ref HEAD', { cwd: repo }, function (err, stdout, stderr) {
+  exec('git show-ref >' + nullPath + ' 2>&1 && git rev-parse --abbrev-ref HEAD', { cwd: repo }, function (err, stdout, stderr) {
     if (err) return cb() // most likely the git repo doesn't have any commits yet
     cb(null, stdout.trim())
   })
 }
 
 exports.ahead = function (repo, cb) {
-  exec('git show-ref >'+nullPath+' 2>&1 && git rev-list HEAD --not --remotes', { cwd: repo }, function (err, stdout, stderr) {
+  exec('git show-ref >' + nullPath + ' 2>&1 && git rev-list HEAD --not --remotes', { cwd: repo }, function (err, stdout, stderr) {
     if (err) return cb(null, NaN) // depending on the state of the git repo, the command might return non-0 exit code
     stdout = stdout.trim()
     cb(null, !stdout ? 0 : parseInt(stdout.split(os.EOL).length, 10))


### PR DESCRIPTION
#4 should be fixed with this.

test.js results:

```
Z:\git-state>node test.js
TAP version 13
# #isGit()
ok 1 should be equal
# #isGitSync()
ok 2 should be equal
# #check()
ok 3 null
ok 4 should be equivalent
ok 5 should be equal
ok 6 should be equal
ok 7 should be equal
ok 8 should be equal
ok 9 should be equal
# #untracked()
ok 10 null
ok 11 should be equal
# #dirty()
ok 12 null
ok 13 should be equal
# #branch()
ok 14 null
ok 15 should be equal
# #ahead()
ok 16 null
ok 17 should be equal
# #commit()
ok 18 null
ok 19 should be equal

1..19
# tests 19
# pass  19

# ok
```
