### PR TITLE
Added synchronous methods for all methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ The result object contains the following properties:
 - `untracked` - The number of untracked files
 - `stashes` - The number of stored stashes
 
+#### `checkSync(path)`
+
+Synchronous version of `check()`. 
+
+Can throw error. This typically happens if you are running a too old 
+version of Node.js (< 0.12), if git isnt found or if the path isn't 
+a git repository.
+
 #### `untracked(path, callback)`
 
 Get the amount of untracked files in the git repository at the given
@@ -67,6 +75,14 @@ Get the amount of untracked files in the git repository at the given
 The `callback` will be called with two arguments: An optional error
 object and a number representing the amount of untracked files.
 
+#### `untrackedSync(path)`
+
+Synchronous version of `untracked()`. 
+
+Can throw error. This typically happens if you are running a too old 
+version of Node.js (< 0.12), if git isnt found or if the path isn't 
+a git repository.
+
 #### `dirty(path, callback)`
 
 Get the amount of dirty files in the git repository at the given
@@ -74,6 +90,14 @@ Get the amount of dirty files in the git repository at the given
 
 The `callback` will be called with two arguments: An optional error
 object and a number representing the amount of dirty files.
+
+#### `dirtySync(path)`
+
+Synchronous version of `dirty() `. 
+
+Can throw error. This typically happens if you are running a too old 
+version of Node.js (< 0.12), if git isnt found or if the path isn't 
+a git repository.
 
 #### `branch(path, callback)`
 
@@ -84,6 +108,10 @@ The `callback` will be called with two arguments: An optional error
 object and a string with the branch name.
 
 If the branch name cannot be found, a falsy value will be returned.
+
+#### `branchSync(path)`
+
+Synchronous version of `branch()`. Returns null if no branch is set.
 
 #### `ahead(path, callback)`
 
@@ -96,6 +124,12 @@ of its remote.
 
 If the number cannot be determined, `NaN` will be returned instead.
 
+#### `aheadSync(path)`
+
+Synchronous version of `ahead()`.
+
+If the number cannot be determined, `NaN` will be returned instead.
+
 #### `commit(path, callback)`
 
 Get the short-hash (e.g. `7b0a3ab`) for the latest commit at `HEAD` in
@@ -104,6 +138,14 @@ the git repository at the given `path`.
 The `callback` will be called with two arguments: An optional error
 object and a string containing the short-hash.
 
+#### `commitSync(path)`
+
+Synchronous version of `commit()`. 
+
+Can throw error. This typically happens if you are running a too old 
+version of Node.js (< 0.12), if git isnt found or if the path isn't 
+a git repository.
+
 #### `stashes(path, callback)`
 
 Get the amount of stashed changes in the git repository at the given
@@ -111,6 +153,14 @@ Get the amount of stashed changes in the git repository at the given
 
 The `callback` will be called with two arguments: An optional error
 object and a number representing the amount of stashed changes.
+
+#### `stashesSync(path)`
+
+Synchronous version of `stashes()`. 
+
+Can throw error. This typically happens if you are running a too old 
+version of Node.js (< 0.12), if git isnt found or if the path isn't 
+a git repository.
 
 ## Shell implementation
 

--- a/index.js
+++ b/index.js
@@ -129,7 +129,7 @@ exports.dirtySync = function (repo) {
 
 exports.branchSync = function (repo) {
   try {
-    var stdout = execSync('git show-ref >' + nullPath + ' 2>&1 && git rev-parse --abbrev-ref HEAD', { cwd: repo }).toString();
+    var stdout = execSync('git show-ref >' + nullPath + ' 2>&1 && git rev-parse --abbrev-ref HEAD', { cwd: repo }).toString()
     return stdout.trim()
   } catch (err) {
     return null // most likely the git repo doesn't have any commits yet
@@ -138,7 +138,7 @@ exports.branchSync = function (repo) {
 
 exports.aheadSync = function (repo) {
   try {
-    var stdout = execSync('git show-ref >' + nullPath + ' 2>&1 && git rev-list HEAD --not --remotes', { cwd: repo }).toString();
+    var stdout = execSync('git show-ref >' + nullPath + ' 2>&1 && git rev-list HEAD --not --remotes', { cwd: repo }).toString()
     stdout = stdout.trim()
     return !stdout ? 0 : parseInt(stdout.split(os.EOL).length, 10)
   } catch (err) {
@@ -148,18 +148,18 @@ exports.aheadSync = function (repo) {
 
 // Throws error
 var statusSync = function (repo) {
-   var stdout = execSync('git status -s', { cwd: repo }).toString();
-   var status = { dirty: 0, untracked: 0 }
-   stdout.trim().split(os.EOL).filter(truthy).forEach(function (file) {
-      if (file.substr(0, 2) === '??') status.untracked++
-      else status.dirty++
-    })
-   return status
+  var stdout = execSync('git status -s', { cwd: repo }).toString()
+  var status = { dirty: 0, untracked: 0 }
+  stdout.trim().split(os.EOL).filter(truthy).forEach(function (file) {
+    if (file.substr(0, 2) === '??') status.untracked++
+    else status.dirty++
+  })
+  return status
 }
 
 // Throws error
 exports.commitSync = function (repo) {
-  var stdout = execSync('git rev-parse --short HEAD', { cwd: repo }).toString();
+  var stdout = execSync('git rev-parse --short HEAD', { cwd: repo }).toString()
   var commitHash = stdout.trim()
   return commitHash
 }

--- a/test.js
+++ b/test.js
@@ -42,8 +42,7 @@ test('#checkSync()', function (t) {
     t.equal(typeof result.dirty, 'number')
     t.equal(typeof result.untracked, 'number')
     t.equal(typeof result.stashes, 'number')
-  }
-  catch(err) {
+  } catch (err) {
     t.error(err)
   }
   t.end()
@@ -63,8 +62,7 @@ test('#untrackedSync()', function (t) {
   try {
     var result = git.untrackedSync(dir)
     t.equal(typeof result, 'number')
-  }
-  catch(err) {
+  } catch (err) {
     t.error(err)
   }
   t.end()
@@ -84,8 +82,7 @@ test('#dirtySync()', function (t) {
   try {
     var result = git.dirtySync(dir)
     t.equal(typeof result, 'number')
-  }
-  catch(err) {
+  } catch (err) {
     t.error(err)
   }
   t.end()
@@ -105,8 +102,7 @@ test('#branchSync()', function (t) {
   try {
     var result = git.branchSync(dir)
     t.equal(typeof result, 'string')
-  }
-  catch(err) {
+  } catch (err) {
     t.error(err)
   }
   t.end()
@@ -126,8 +122,7 @@ test('#aheadSync()', function (t) {
   try {
     var result = git.aheadSync(dir)
     t.equal(typeof result, 'number')
-  }
-  catch(err) {
+  } catch (err) {
     t.error(err)
   }
   t.end()
@@ -147,8 +142,7 @@ test('#commitSync()', function (t) {
   try {
     var result = git.commitSync(dir)
     t.equal(typeof result, 'string')
-  }
-  catch(err) {
+  } catch (err) {
     t.error(err)
   }
   t.end()
@@ -168,8 +162,7 @@ test('#stashesSync()', function (t) {
   try {
     var result = git.stashesSync(dir)
     t.equal(typeof result, 'number')
-  }
-  catch(err) {
+  } catch (err) {
     t.error(err)
   }
   t.end()

--- a/test.js
+++ b/test.js
@@ -32,6 +32,23 @@ test('#check()', function (t) {
   })
 })
 
+test('#checkSync()', function (t) {
+  var dir = process.cwd()
+  try {
+    var result = git.checkSync(dir)
+    t.deepEqual(Object.keys(result), ['branch', 'ahead', 'dirty', 'untracked', 'stashes'])
+    t.equal(typeof result.branch, 'string')
+    t.equal(typeof result.ahead, 'number')
+    t.equal(typeof result.dirty, 'number')
+    t.equal(typeof result.untracked, 'number')
+    t.equal(typeof result.stashes, 'number')
+  }
+  catch(err) {
+    t.error(err)
+  }
+  t.end()
+})
+
 test('#untracked()', function (t) {
   var dir = process.cwd()
   git.untracked(dir, function (err, result) {
@@ -39,6 +56,18 @@ test('#untracked()', function (t) {
     t.equal(typeof result, 'number')
     t.end()
   })
+})
+
+test('#untrackedSync()', function (t) {
+  var dir = process.cwd()
+  try {
+    var result = git.untrackedSync(dir)
+    t.equal(typeof result, 'number')
+  }
+  catch(err) {
+    t.error(err)
+  }
+  t.end()
 })
 
 test('#dirty()', function (t) {
@@ -50,6 +79,18 @@ test('#dirty()', function (t) {
   })
 })
 
+test('#dirtySync()', function (t) {
+  var dir = process.cwd()
+  try {
+    var result = git.dirtySync(dir)
+    t.equal(typeof result, 'number')
+  }
+  catch(err) {
+    t.error(err)
+  }
+  t.end()
+})
+
 test('#branch()', function (t) {
   var dir = process.cwd()
   git.branch(dir, function (err, result) {
@@ -57,6 +98,18 @@ test('#branch()', function (t) {
     t.equal(typeof result, 'string')
     t.end()
   })
+})
+
+test('#branchSync()', function (t) {
+  var dir = process.cwd()
+  try {
+    var result = git.branchSync(dir)
+    t.equal(typeof result, 'string')
+  }
+  catch(err) {
+    t.error(err)
+  }
+  t.end()
 })
 
 test('#ahead()', function (t) {
@@ -68,6 +121,18 @@ test('#ahead()', function (t) {
   })
 })
 
+test('#aheadSync()', function (t) {
+  var dir = process.cwd()
+  try {
+    var result = git.aheadSync(dir)
+    t.equal(typeof result, 'number')
+  }
+  catch(err) {
+    t.error(err)
+  }
+  t.end()
+})
+
 test('#commit()', function (t) {
   var dir = process.cwd()
   git.commit(dir, function (err, result) {
@@ -77,6 +142,18 @@ test('#commit()', function (t) {
   })
 })
 
+test('#commitSync()', function (t) {
+  var dir = process.cwd()
+  try {
+    var result = git.commitSync(dir)
+    t.equal(typeof result, 'string')
+  }
+  catch(err) {
+    t.error(err)
+  }
+  t.end()
+})
+
 test('#stashes()', function (t) {
   var dir = process.cwd()
   git.stashes(dir, function (err, result) {
@@ -84,4 +161,16 @@ test('#stashes()', function (t) {
     t.equal(typeof result, 'number')
     t.end()
   })
+})
+
+test('#stashesSync()', function (t) {
+  var dir = process.cwd()
+  try {
+    var result = git.stashesSync(dir)
+    t.equal(typeof result, 'number')
+  }
+  catch(err) {
+    t.error(err)
+  }
+  t.end()
 })


### PR DESCRIPTION
Added synchronous methods for all the async methods. These are named <method>Sync.

Main difference is that they use child_process.execSync (available in Node.js >= 0.11.12) instead of child_process.exec.

Instead of the usual cb(err, res) these will simply return the same values or throw an error. The exceptions to this is branchSync that will return null on error and aheadSync that will return NaN if a error is thrown.